### PR TITLE
[circle-opselector-test] edit nncc overlay dir venv version

### DIFF
--- a/compiler/circle-opselector-test/CMakeLists.txt
+++ b/compiler/circle-opselector-test/CMakeLists.txt
@@ -20,7 +20,7 @@ add_test(NAME circle_opselector_value_test
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/compare_circles.sh"
           "${CMAKE_CURRENT_BINARY_DIR}"
           "${ARTIFACTS_BIN_PATH}"
-          "${NNCC_OVERLAY_DIR}/venv_2_3_0"
+          "${NNCC_OVERLAY_DIR}/venv_2_6_0"
           "$<TARGET_FILE:luci_eval_driver>"
           "$<TARGET_FILE:circle-opselector>"
           "${CIRCLE_OPSELECTOR_TEST}"


### PR DESCRIPTION
from 2.3 to 2.6

ONE-DCO-1.0-Signed-off-by: parkeunsang <dislive@naver.com>